### PR TITLE
Allow more digits for _N parameter suffix

### DIFF
--- a/src/KasApi/KasApi.php
+++ b/src/KasApi/KasApi.php
@@ -212,7 +212,7 @@ class KasApi {
      */
     protected function paramIsAllowed($param, $function) {
         $allowed_params = $this->allowedParams($function);
-        return in_array("$param!", $allowed_params) || in_array($param, $allowed_params) || (preg_match('/_[0-9]$/', $param) && in_array("target_N", $allowed_params) && strpos($param,'target_') !== false);
+        return in_array("$param!", $allowed_params) || in_array($param, $allowed_params) || (preg_match('/_[0-9]+$/', $param) && in_array("target_N", $allowed_params) && strpos($param,'target_') !== false);
     }
 
     /**


### PR DESCRIPTION
E.g. the function update_mailforward allows more than 10 forwarding targets, not just 0-9.