### PR TITLE
Fixed syntax error in PHP < 5.4

### DIFF
--- a/src/KasApi/KasApi.php
+++ b/src/KasApi/KasApi.php
@@ -138,7 +138,8 @@ class KasApi {
                 'KasAuthData' => $this->kasConfiguration->_authData,
                 'KasRequestType' => $function,
                 'KasRequestParams' => $params);
-            $client = (new KasSoapClient($this->kasConfiguration->wsdl_api))->getInstance();
+            $kasSoapClient = new KasSoapClient($this->kasConfiguration->wsdl_api);
+            $client = $kasSoapClient->getInstance();
             $result = $client->KasApi(json_encode($data));
             $this->kasFloodDelay = $result['Response']['KasFloodDelay'];
             return $result['Response']['ReturnInfo'];


### PR DESCRIPTION
Raised an "unexpected T_OBJECT_OPERATOR" syntax error in PHP < 5.4