### PR TITLE
Implementing automatic KasFloodDelay management (fixes #10)

### DIFF
--- a/src/KasApi/KasConfiguration.php
+++ b/src/KasApi/KasConfiguration.php
@@ -30,6 +30,13 @@ class KasConfiguration {
      */
     public $_authType = "sha1";
 
+	/**
+	 * Automatic Delay for Api Calls
+	 *
+	 * Manages whether KasApi should use sleep to automagically manage kasFloodDelay
+	 */
+	public $_autoDelayApiCalls;
+
     /**
      * WSDL file for KAS API
      *
@@ -43,10 +50,12 @@ class KasConfiguration {
      * @param string $username
      * @param string $authData
      * @param string $authType
+     * @param bool $autoDelayApiCalls
      */
-    function __construct($username, $authData, $authType) {
+    function __construct($username, $authData, $authType, $autoDelayApiCalls = false) {
         $this->_username = $username;
         $this->_authData = $authData;
         $this->_authType = $authType;
+        $this->_autoDelayApiCalls = $autoDelayApiCalls;
     }
 }


### PR DESCRIPTION
This implements automatic management of KasFloodDelay via an option in KasConfiguration.
The new option defaults to false to allow for backwards compatibility.

fixes #10 