### PR TITLE
added parameter 'session_2fa'

### DIFF
--- a/src/KasApi/KasApi.php
+++ b/src/KasApi/KasApi.php
@@ -183,7 +183,7 @@ class KasApi {
         'add_sambauser' => 'samba_path!, samba_new_password!, samba_comment',
         'delete_sambauser' => 'samba_login!',
         'update_sambauser' => 'samba_login!, samba_path, samba_new_password, samba_comment',
-        'add_session' => 'session_lifetime!, session_update_lifetime!',
+        'add_session' => 'session_lifetime!, session_update_lifetime!, session_2fa',
         'add_softwareinstall' => 'software_id!, software_database!, software_hostname!, software_path!, software_admin_mail!, software_admin_user, software_admin_pass, language, software_team',
         'add_subdomain' => 'subdomain_name!, domain_name!, subdomain_path, redirect_status, ssl_proxy, statistic_version, statistic_language, php_version',
         'delete_subdomain' => 'subdomain_name!',


### PR DESCRIPTION
It was not possible to authenticate with 2-step authentication because 

https://github.com/waza-ari/kasapi-php/blob/master/src/KasApi/KasApi.php#L321
```
if (!$this->paramIsAllowed($param, $function))
                throw new KasApiException("API parameter '$param' may not be used");
```
prevented the authentication.

The `session_2fa` parameter is added, which is necessary to successfully use accounts with 2-step authentication.